### PR TITLE
Updated dpd.sig to prevent other protocols being logged as HART-IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ testing/.btest.failed.dat
 
 # Don't ignore baseline log files
 !testing/baseline/*/*.log
+
+# Build directory
+build/

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -6,29 +6,54 @@
 # Third byte: 0x00 - 0x05
 # Fourth byte: 0x00, 0x02, 0x05, 0x06, 0x08, 0x09, 0x0e, 0x0f, 0x10, 0x1e
 
-# See: https://github.com/cisagov/icsnpp-hart-ip/issues/21
-# Originally added a SIP signature here but it was breaking the hart_ip btest
-# Instead removed type 3 message (\x03 pattern) because it seemingly loosely matched RDP traffic
+signature dpd_hart_ip_session_initiate {
+    payload /^[\x01\x02][\x00-\x02\x0f]/
+}
 
-signature dpd_hart_ip {
-    # Pattern breakdown:
-    # 1. Session initiate: [\x01\x02][\x00-\x02\x0f]\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e]...
-    # 2. Type 1 messages: \x01[\x00\x06]...
-    # 3. Type 2 messages: \x02[\x00\x06]...  
-    # 4. Type 4 messages: \x04[\x00\x06\x10]...
-    # 5. Type 5 messages: \x05[\x00\x06\x08]...
+signature dpd_hart_ip_msg_0 {
+    payload /^(\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})/
+}
 
-    payload /^[\x01\x02][\x00-\x02\x0f](\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})|(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x04[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{3,})+)|(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
+signature dpd_hart_ip_msg_1 {
+    payload /^(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)/
+}
+
+signature dpd_hart_ip_msg_2 {
+    payload /^(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)/
+}
+
+signature dpd_hart_ip_msg_3 {
+    payload /^(\x03[\x80-\xff\x00-\x3f]([\x00-\xff]{4})?[\x00-\xff][\x00-\xff][\x00-\xff]{0,255}[\x00-\xff])/
+}
+
+signature dpd_hart_ip_msg_4 {
+    payload /^(\x04[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{3,})+)/
+}
+
+signature dpd_hart_ip_msg_5 {
+    payload /^(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
 }
 
 signature dpd_hart_ip_tcp {
   ip-proto == tcp
-  requires-signature dpd_hart_ip
+    requires-signature dpd_hart_ip_session_initiate
+    requires-signature dpd_hart_ip_msg_0
+    requires-signature dpd_hart_ip_msg_1
+    requires-signature dpd_hart_ip_msg_2
+    requires-signature dpd_hart_ip_msg_3
+    requires-signature dpd_hart_ip_msg_4
+    requires-signature dpd_hart_ip_msg_5
   enable "spicy_HART_IP_TCP"
 }
 
 signature dpd_hart_ip_udp {
   ip-proto == udp
-  requires-signature dpd_hart_ip
+  requires-signature dpd_hart_ip_session_initiate
+  requires-signature dpd_hart_ip_msg_0
+  requires-signature dpd_hart_ip_msg_1
+  requires-signature dpd_hart_ip_msg_2
+  requires-signature dpd_hart_ip_msg_3
+  requires-signature dpd_hart_ip_msg_4
+  requires-signature dpd_hart_ip_msg_5
   enable "spicy_HART_IP_UDP"
 }

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -14,7 +14,11 @@
 
 signature dpd_sip_header {
     # Match either a SIP request line (method SP ...) or a SIP response line (SIP/2.0 ...)
-    payload/^((INVITE|REGISTER|OPTIONS|ACK|BYE|CANCEL|SUBSCRIBE|NOTIFY|PUBLISH|MESSAGE|INFO|PRACK|UPDATE|REFER) [^\r\n]+|SIP\/2\.0)/
+    # The SIP response line is of the form "SIP/2.0 <status-code> <reason-phrase>\r\n".
+    # Require a three–digit status code followed by a space in order to avoid
+    # accidental matches of binary protocols whose first bytes might coincide
+    # with the ASCII string "SIP/2.0".
+    payload/^((INVITE|REGISTER|OPTIONS|ACK|BYE|CANCEL|SUBSCRIBE|NOTIFY|PUBLISH|MESSAGE|INFO|PRACK|UPDATE|REFER) [^\r\n]+|SIP\/2\.0 [1-6][0-9]{2} )/
 }
 
 signature dpd_hart_ip {

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -6,7 +6,20 @@
 # Third byte: 0x00 - 0x05
 # Fourth byte: 0x00, 0x02, 0x05, 0x06, 0x08, 0x09, 0x0e, 0x0f, 0x10, 0x1e
 
+# Signature to recognize SIP headers so that we can explicitly exclude
+# those connections from being interpreted as HART-IP.  We only care
+# about the very first line of the first packet in the flow, which for
+# SIP is plain-text starting with one of the request methods or the
+# response line "SIP/2.0".
+
+signature dpd_sip_header {
+    # Match either a SIP request line (method SP ...) or a SIP response line (SIP/2.0 ...)
+    payload/^((INVITE|REGISTER|OPTIONS|ACK|BYE|CANCEL|SUBSCRIBE|NOTIFY|PUBLISH|MESSAGE|INFO|PRACK|UPDATE|REFER) [^\r\n]+|SIP\/2\.0)/
+}
+
 signature dpd_hart_ip {
+    # Ensure this signature does *not* fire on flows already identified as SIP.
+    requires-signature !dpd_sip_header
     #payload /^[\x01\x02][\x00-\x02\x0f][\x00-\x05][\x00\x02\x05\x06\x08\x09\x0e\x0f\x10\x1e]/
     payload/^[\x01\x02][\x00-\x02\x0f](\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})|(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x03[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{4})?[\x00-\xff]{3,})|(\x04[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{3,})+)|(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
 }

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -6,26 +6,17 @@
 # Third byte: 0x00 - 0x05
 # Fourth byte: 0x00, 0x02, 0x05, 0x06, 0x08, 0x09, 0x0e, 0x0f, 0x10, 0x1e
 
-# Signature to recognize SIP headers so that we can explicitly exclude
-# those connections from being interpreted as HART-IP.  We only care
-# about the very first line of the first packet in the flow, which for
-# SIP is plain-text starting with one of the request methods or the
-# response line "SIP/2.0".
-
-signature dpd_sip_header {
-    # Match either a SIP request line (method SP ...) or a SIP response line (SIP/2.0 ...)
-    # The SIP response line is of the form "SIP/2.0 <status-code> <reason-phrase>\r\n".
-    # Require a three–digit status code followed by a space in order to avoid
-    # accidental matches of binary protocols whose first bytes might coincide
-    # with the ASCII string "SIP/2.0".
-    payload/^((INVITE|REGISTER|OPTIONS|ACK|BYE|CANCEL|SUBSCRIBE|NOTIFY|PUBLISH|MESSAGE|INFO|PRACK|UPDATE|REFER) [^\r\n]+|SIP\/2\.0 [1-6][0-9]{2} )/
-}
 
 signature dpd_hart_ip {
-    # Ensure this signature does *not* fire on flows already identified as SIP.
-    requires-signature !dpd_sip_header
-    #payload /^[\x01\x02][\x00-\x02\x0f][\x00-\x05][\x00\x02\x05\x06\x08\x09\x0e\x0f\x10\x1e]/
-    payload/^[\x01\x02][\x00-\x02\x0f](\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})|(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x03[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{4})?[\x00-\xff]{3,})|(\x04[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{3,})+)|(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
+    # Pattern breakdown:
+    # 1. Session initiate: [\x01\x02][\x00-\x02\x0f]\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e]...
+    # 2. Type 1 messages: \x01[\x00\x06]...
+    # 3. Type 2 messages: \x02[\x00\x06]...  
+    # 4. Type 4 messages: \x04[\x00\x06\x10]...
+    # 5. Type 5 messages: \x05[\x00\x06\x08]...
+    #
+    # NOTE: \x03 pattern was removed because it matched RDP traffic (0x03 0x00...)
+    payload /^[\x01\x02][\x00-\x02\x0f](\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})|(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x04[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{3,})+)|(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
 }
 
 signature dpd_hart_ip_tcp {

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -6,54 +6,18 @@
 # Third byte: 0x00 - 0x05
 # Fourth byte: 0x00, 0x02, 0x05, 0x06, 0x08, 0x09, 0x0e, 0x0f, 0x10, 0x1e
 
-signature dpd_hart_ip_session_initiate {
-    payload /^[\x01\x02][\x00-\x02\x0f]/
-}
-
-signature dpd_hart_ip_msg_0 {
-    payload /^(\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})/
-}
-
-signature dpd_hart_ip_msg_1 {
-    payload /^(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)/
-}
-
-signature dpd_hart_ip_msg_2 {
-    payload /^(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)/
-}
-
-signature dpd_hart_ip_msg_3 {
-    payload /^(\x03[\x80-\xff\x00-\x3f]([\x00-\xff]{4})?[\x00-\xff][\x00-\xff][\x00-\xff]{0,255}[\x00-\xff])/
-}
-
-signature dpd_hart_ip_msg_4 {
-    payload /^(\x04[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{3,})+)/
-}
-
-signature dpd_hart_ip_msg_5 {
-    payload /^(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
+signature dpd_hart_ip {
+    payload /^[\x01\x02][\x00-\x02\x0f](\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})|(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x03[\x02\x06\x15\x82][\x00-\xff]{6}([\x00-\xff]{4})?[\x00-\xff]{3,})|(\x04[\x02\x06\x15\x82][\x00-\xff]{6}([\x00-\xff]{3,})+)|(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
 }
 
 signature dpd_hart_ip_tcp {
   ip-proto == tcp
-    requires-signature dpd_hart_ip_session_initiate
-    requires-signature dpd_hart_ip_msg_0
-    requires-signature dpd_hart_ip_msg_1
-    requires-signature dpd_hart_ip_msg_2
-    requires-signature dpd_hart_ip_msg_3
-    requires-signature dpd_hart_ip_msg_4
-    requires-signature dpd_hart_ip_msg_5
+    requires-signature dpd_hart_ip
   enable "spicy_HART_IP_TCP"
 }
 
 signature dpd_hart_ip_udp {
   ip-proto == udp
-  requires-signature dpd_hart_ip_session_initiate
-  requires-signature dpd_hart_ip_msg_0
-  requires-signature dpd_hart_ip_msg_1
-  requires-signature dpd_hart_ip_msg_2
-  requires-signature dpd_hart_ip_msg_3
-  requires-signature dpd_hart_ip_msg_4
-  requires-signature dpd_hart_ip_msg_5
+  requires-signature dpd_hart_ip
   enable "spicy_HART_IP_UDP"
 }

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -12,7 +12,7 @@ signature dpd_hart_ip {
 
 signature dpd_hart_ip_tcp {
   ip-proto == tcp
-    requires-signature dpd_hart_ip
+  requires-signature dpd_hart_ip
   enable "spicy_HART_IP_TCP"
 }
 

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -6,7 +6,6 @@
 # Third byte: 0x00 - 0x05
 # Fourth byte: 0x00, 0x02, 0x05, 0x06, 0x08, 0x09, 0x0e, 0x0f, 0x10, 0x1e
 
-
 signature dpd_hart_ip {
     # Pattern breakdown:
     # 1. Session initiate: [\x01\x02][\x00-\x02\x0f]\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e]...

--- a/scripts/dpd.sig
+++ b/scripts/dpd.sig
@@ -6,6 +6,10 @@
 # Third byte: 0x00 - 0x05
 # Fourth byte: 0x00, 0x02, 0x05, 0x06, 0x08, 0x09, 0x0e, 0x0f, 0x10, 0x1e
 
+# See: https://github.com/cisagov/icsnpp-hart-ip/issues/21
+# Originally added a SIP signature here but it was breaking the hart_ip btest
+# Instead removed type 3 message (\x03 pattern) because it seemingly loosely matched RDP traffic
+
 signature dpd_hart_ip {
     # Pattern breakdown:
     # 1. Session initiate: [\x01\x02][\x00-\x02\x0f]\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e]...
@@ -13,8 +17,7 @@ signature dpd_hart_ip {
     # 3. Type 2 messages: \x02[\x00\x06]...  
     # 4. Type 4 messages: \x04[\x00\x06\x10]...
     # 5. Type 5 messages: \x05[\x00\x06\x08]...
-    #
-    # NOTE: \x03 pattern was removed because it matched RDP traffic (0x03 0x00...)
+
     payload /^[\x01\x02][\x00-\x02\x0f](\x00[\x00\x05\x06\x08\x09\x0e\x0f\x10\x1e][\x00-\xff]{2}\x00\x0d[\x00-\xff]{5})|(\x01[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x02[\x00\x06][\x00-\xff]{2}\x00\x08)|(\x04[\x00\x06\x10][\x00-\xff]{6}([\x00-\xff]{3,})+)|(\x05[\x00\x06\x08][\x00-\xff]{6}([\x00-\xff]{17}[\x00-\x07][\x00-\xff]{2}([\x00-\xff]{40}[\x00-\x1f][\x00-\xff]{16})+)?)/
 }
 


### PR DESCRIPTION
## 🗣 Description ##

Addressing https://github.com/cisagov/icsnpp-hart-ip/issues/21

## 💭 Motivation and context ##

It looks like our signature for HART-IP was too lenient and falsely matching other protocols. I have updated the dpd.sig file and removed the pattern that was matching the data provided in the pcap in the comments of the attached issue. See issue for more context. 

## 🧪 Testing ##

Cloned repo, built, and ran user's pcap through zeek. Saw `hart_ip_general.log` get generated.
Switch to branch and ran user's pcap through zeek. No `hart_ip_general.log` generated.
Ran btests and all passed.

## 📷 Screenshots (if appropriate) ##

See attached terminal output. Top screenshot shows output of btest testing along with git commit.
Bottom left shows zeek using the updated signature with user's supplied pcap and no `hart_ip_general.log` is generated.
Bottom right shows `main` branch running with user's supplied pcap and `hart_ip_general.log` is generated. Ignore that it displays `hart_ip_general.loghart_ip_general.log`. That is a display bug when using `eza` (my `ls` is aliased to `eza`) and `grep` together.
![image](https://github.com/user-attachments/assets/d4dcdd8b-e452-4469-9acb-98f8ce463aef)

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [X] All new and existing tests pass.
