### PR TITLE
replace 'std::string' with 'hilti::rt::String' for spicy 1.16 and fix incorrect random_device use

### DIFF
--- a/analyzer/hart_ip_conversion.cc
+++ b/analyzer/hart_ip_conversion.cc
@@ -22,37 +22,38 @@ namespace HART_IP_CONVERSION
         if(data.size() < 3)
         {
             printf("[error] Date Type Improper Byte Length (%li), must be 3\n", (long) data.size());
-            return "";
+            return hilti::rt::String();
         }
 
         const char *char_ptr = (const char *) data.data();
-	
+
         unsigned char day = char_ptr[0];
         unsigned char month = char_ptr[1];
         unsigned char shortYear = char_ptr[2];
         unsigned int longYear = 1900 + shortYear;
 
-	// Month name lookup
-	// Lines from here to end of function are additions
-	// for converting to Month Day, Year format
+    // Month name lookup
+    // Lines from here to end of function are additions
+    // for converting to Month Day, Year format
     // Default logging as Month (string) Day, Year
-    	static const hilti::rt::String months[] = {
-        	"", "January", "February", "March", "April", "May", "June",
-        	"July", "August", "September", "October", "November", "December"
-    	};
+        static const std::string months[] = {
+            "", "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December"
+        };
 
-	hilti::rt::String monthName = "";
-	if(month >= 1 && month <= 12) {
-		monthName = months[month];
-	}
-	else {
-		monthName = "InvalidMonth";
-	}
+    std::string monthName;
+    if(month >= 1 && month <= 12) {
+        monthName = months[month];
+    }
+    else {
+        monthName = "InvalidMonth";
+    }
 
-	return monthName + " " + std::to_string(day) + ", " + std::to_string(longYear);
+    std::string result = monthName + " " + std::to_string(day) + ", " + std::to_string(longYear);
+    return hilti::rt::String(std::string_view(result));
 
     // Remove the comments on lines 58-60 and comment out lines 43-56 to log as Month-Day-Year in integers
-	//return std::to_string(month) + "-" +
+    //return std::to_string(month) + "-" +
         //       std::to_string(day) + "-" +
         //       std::to_string(longYear);
     }
@@ -64,7 +65,7 @@ namespace HART_IP_CONVERSION
         if(data.size() < 4)
         {
             printf("[error] Time Type Improper Byte Length (%li), must be 4\n", (long) data.size());
-            return "";
+            return hilti::rt::String();
         }
         const char *char_ptr = (const char *) data.data();
         unsigned int time = 0;
@@ -81,8 +82,8 @@ namespace HART_IP_CONVERSION
         unsigned int minutesPart = totalMinutes % MINUTES_PER_HOUR;
         unsigned int hoursPart = totalMinutes / MINUTES_PER_HOUR;
 
-        hilti::rt::String returnString = "";
-        hilti::rt::String tempString = "";
+        std::string returnString;
+        std::string tempString;
         if(0 < secondsPart || 0.0 < fractionPart)
         {
             returnString = std::to_string(fractionPart + secondsPart) +
@@ -91,7 +92,7 @@ namespace HART_IP_CONVERSION
         if(0 < minutesPart)
         {
             tempString = std::to_string(minutesPart) + " minutes";
-            if("" != returnString)
+            if(!returnString.empty())
             {
                 tempString += ", ";
             }
@@ -100,14 +101,14 @@ namespace HART_IP_CONVERSION
         if(0 < hoursPart)
         {
             tempString = std::to_string(hoursPart) + " hours";
-            if("" != returnString)
+            if(!returnString.empty())
             {
                 tempString += ", ";
             }
             returnString = tempString + returnString;
         }
 
-        return returnString;
+        return hilti::rt::String(std::string_view(returnString));
     }
 
     hilti::rt::String packedConversion(const hilti::rt::Bytes &data)    {
@@ -117,12 +118,12 @@ namespace HART_IP_CONVERSION
         const int NEEDED_BITS = BITS_PER_BYTE / OUTPUT_CHARS * INPUT_CHARS;
         // MAP from TS20099 (v11.0) 5.1.1, Table 1
         // Note: there are other ways to do this, this just seems easy for now.
-        const hilti::rt::String MAP = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
-            
+        const std::string MAP = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
+
         if(0 != data.size() % INPUT_CHARS)
         {
             printf("[error] Packed Type Improper Byte Length (%li), must be divisible by %i\n", (long) data.size(), INPUT_CHARS);
-            return "";
+            return hilti::rt::String();
         }
         std::string outputString;
 
@@ -153,7 +154,7 @@ namespace HART_IP_CONVERSION
                     else
                     {
                         printf("[error] Packed Type Improper Character Encoding\n");
-                        return "";
+                        return hilti::rt::String();
                     }
                     // Reset things in preparation for the next set of NEEDED_BITS
                     processedBits = 0;
@@ -166,4 +167,3 @@ namespace HART_IP_CONVERSION
     }
 
 }
-

--- a/analyzer/hart_ip_conversion.cc
+++ b/analyzer/hart_ip_conversion.cc
@@ -8,8 +8,8 @@
 
 namespace HART_IP_CONVERSION
 {
-    std::string latin1Conversion(const hilti::rt::Bytes &data)    {
-        std::string returnValue;
+    hilti::rt::String latin1Conversion(const hilti::rt::Bytes &data)    {
+        hilti::rt::String returnValue;
         const char *char_ptr = (const char *) data.data();
         for(std::size_t i = 0; i < data.size(); ++i)
         {
@@ -22,7 +22,7 @@ namespace HART_IP_CONVERSION
         return returnValue;
     }
 
-    std::string dateConversion(const hilti::rt::Bytes &data)    {
+    hilti::rt::String dateConversion(const hilti::rt::Bytes &data)    {
         if(data.size() < 3)
         {
             printf("[error] Date Type Improper Byte Length (%li), must be 3\n", (long) data.size());
@@ -40,12 +40,12 @@ namespace HART_IP_CONVERSION
 	// Lines from here to end of function are additions
 	// for converting to Month Day, Year format
     // Default logging as Month (string) Day, Year
-    	static const std::string months[] = {
+    	static const hilti::rt::String months[] = {
         	"", "January", "February", "March", "April", "May", "June",
         	"July", "August", "September", "October", "November", "December"
     	};
 
-	std::string monthName = "";
+	hilti::rt::String monthName = "";
 	if(month >= 1 && month <= 12) {
 		monthName = months[month];
 	}
@@ -61,7 +61,7 @@ namespace HART_IP_CONVERSION
         //       std::to_string(longYear);
     }
 
-    std::string timeConversion(const hilti::rt::Bytes &data)    {
+    hilti::rt::String timeConversion(const hilti::rt::Bytes &data)    {
         const unsigned int MILLISECOND_PARTS = 32;
         const unsigned int SECONDS_PER_MINUTE = 60;
         const unsigned int MINUTES_PER_HOUR = 60;
@@ -85,8 +85,8 @@ namespace HART_IP_CONVERSION
         unsigned int minutesPart = totalMinutes % MINUTES_PER_HOUR;
         unsigned int hoursPart = totalMinutes / MINUTES_PER_HOUR;
 
-        std::string returnString = "";
-        std::string tempString = "";
+        hilti::rt::String returnString = "";
+        hilti::rt::String tempString = "";
         if(0 < secondsPart || 0.0 < fractionPart)
         {
             returnString = std::to_string(fractionPart + secondsPart) +
@@ -114,21 +114,21 @@ namespace HART_IP_CONVERSION
         return returnString;
     }
 
-    std::string packedConversion(const hilti::rt::Bytes &data)    {
+    hilti::rt::String packedConversion(const hilti::rt::Bytes &data)    {
         const int INPUT_CHARS = 3;
         const int OUTPUT_CHARS = 4;
         const int BITS_PER_BYTE = 8;
         const int NEEDED_BITS = BITS_PER_BYTE / OUTPUT_CHARS * INPUT_CHARS;
         // MAP from TS20099 (v11.0) 5.1.1, Table 1
         // Note: there are other ways to do this, this just seems easy for now.
-        const std::string MAP = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
+        const hilti::rt::String MAP = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
             
         if(0 != data.size() % INPUT_CHARS)
         {
             printf("[error] Packed Type Improper Byte Length (%li), must be divisible by %i\n", (long) data.size(), INPUT_CHARS);
             return "";
         }
-        std::string outputString;
+        hilti::rt::String outputString;
 
         unsigned char tempChar = 0;
         int processedBits = 0;

--- a/analyzer/hart_ip_conversion.cc
+++ b/analyzer/hart_ip_conversion.cc
@@ -8,21 +8,31 @@
 
 namespace HART_IP_CONVERSION
 {
-    hilti::rt::String latin1Conversion(const hilti::rt::Bytes &data) {
+    // Spicy exports its version in `PROJECT_VERSION_NUMBER`.
+    // hilti::rt::String was introduced in HILTI 1.16 (Zeek 8.2.1); on
+    // earlier versions (e.g. Zeek 8.0.9 / HILTI 1.14.2) it doesn't exist,
+    // so fall back to std::string there.
+#if PROJECT_VERSION_NUMBER >= 11600
+    using SpicyString = hilti::rt::String;
+#else
+    using SpicyString = std::string;
+#endif
+
+    SpicyString latin1Conversion(const hilti::rt::Bytes &data) {
         std::string returnValue;
         returnValue.reserve(data.size());
         const char *char_ptr = (const char *) data.data();
         for (std::size_t i = 0; i < data.size(); ++i) {
             returnValue += char_ptr[i];
         }
-        return hilti::rt::String(std::string_view(returnValue));
+        return {returnValue};
     }
 
-    hilti::rt::String dateConversion(const hilti::rt::Bytes &data)    {
+    SpicyString dateConversion(const hilti::rt::Bytes &data)    {
         if(data.size() < 3)
         {
             printf("[error] Date Type Improper Byte Length (%li), must be 3\n", (long) data.size());
-            return hilti::rt::String();
+            return {};
         }
 
         const char *char_ptr = (const char *) data.data();
@@ -50,7 +60,7 @@ namespace HART_IP_CONVERSION
     }
 
     std::string result = monthName + " " + std::to_string(day) + ", " + std::to_string(longYear);
-    return hilti::rt::String(std::string_view(result));
+    return {result};
 
     // Remove the comments on lines 58-60 and comment out lines 43-56 to log as Month-Day-Year in integers
     //return std::to_string(month) + "-" +
@@ -58,14 +68,14 @@ namespace HART_IP_CONVERSION
         //       std::to_string(longYear);
     }
 
-    hilti::rt::String timeConversion(const hilti::rt::Bytes &data)    {
+    SpicyString timeConversion(const hilti::rt::Bytes &data)    {
         const unsigned int MILLISECOND_PARTS = 32;
         const unsigned int SECONDS_PER_MINUTE = 60;
         const unsigned int MINUTES_PER_HOUR = 60;
         if(data.size() < 4)
         {
             printf("[error] Time Type Improper Byte Length (%li), must be 4\n", (long) data.size());
-            return hilti::rt::String();
+            return {};
         }
         const char *char_ptr = (const char *) data.data();
         unsigned int time = 0;
@@ -108,10 +118,10 @@ namespace HART_IP_CONVERSION
             returnString = tempString + returnString;
         }
 
-        return hilti::rt::String(std::string_view(returnString));
+        return {returnString};
     }
 
-    hilti::rt::String packedConversion(const hilti::rt::Bytes &data)    {
+    SpicyString packedConversion(const hilti::rt::Bytes &data)    {
         const int INPUT_CHARS = 3;
         const int OUTPUT_CHARS = 4;
         const int BITS_PER_BYTE = 8;
@@ -123,7 +133,7 @@ namespace HART_IP_CONVERSION
         if(0 != data.size() % INPUT_CHARS)
         {
             printf("[error] Packed Type Improper Byte Length (%li), must be divisible by %i\n", (long) data.size(), INPUT_CHARS);
-            return hilti::rt::String();
+            return {};
         }
         std::string outputString;
 
@@ -154,7 +164,7 @@ namespace HART_IP_CONVERSION
                     else
                     {
                         printf("[error] Packed Type Improper Character Encoding\n");
-                        return hilti::rt::String();
+                        return {};
                     }
                     // Reset things in preparation for the next set of NEEDED_BITS
                     processedBits = 0;
@@ -163,7 +173,7 @@ namespace HART_IP_CONVERSION
             }
         }
 
-        return hilti::rt::String(std::string_view(outputString));
+        return {outputString};
     }
 
 }

--- a/analyzer/hart_ip_conversion.cc
+++ b/analyzer/hart_ip_conversion.cc
@@ -8,18 +8,14 @@
 
 namespace HART_IP_CONVERSION
 {
-    hilti::rt::String latin1Conversion(const hilti::rt::Bytes &data)    {
-        hilti::rt::String returnValue;
+    hilti::rt::String latin1Conversion(const hilti::rt::Bytes &data) {
+        std::string returnValue;
+        returnValue.reserve(data.size());
         const char *char_ptr = (const char *) data.data();
-        for(std::size_t i = 0; i < data.size(); ++i)
-        {
-            //if(0 == char_ptr[i])
-            //{
-            //    break;
-            //}
+        for (std::size_t i = 0; i < data.size(); ++i) {
             returnValue += char_ptr[i];
         }
-        return returnValue;
+        return hilti::rt::String(std::string_view(returnValue));
     }
 
     hilti::rt::String dateConversion(const hilti::rt::Bytes &data)    {
@@ -128,7 +124,7 @@ namespace HART_IP_CONVERSION
             printf("[error] Packed Type Improper Byte Length (%li), must be divisible by %i\n", (long) data.size(), INPUT_CHARS);
             return "";
         }
-        hilti::rt::String outputString;
+        std::string outputString;
 
         unsigned char tempChar = 0;
         int processedBits = 0;
@@ -166,7 +162,7 @@ namespace HART_IP_CONVERSION
             }
         }
 
-        return outputString;
+        return hilti::rt::String(std::string_view(outputString));
     }
 
 }

--- a/analyzer/hart_ip_generateid.cc
+++ b/analyzer/hart_ip_generateid.cc
@@ -10,13 +10,30 @@ namespace HART_IP_GENERATEID
 {
     #define ID_LEN 9
 
-    hilti::rt::String generateId() {
+    // Spicy exports its version in `PROJECT_VERSION_NUMBER`.
+    // hilti::rt::String was introduced in HILTI 1.16 (Zeek 8.2.1); on
+    // earlier versions (e.g. Zeek 8.0.9 / HILTI 1.14.2) it doesn't exist,
+    // so fall back to std::string there.
+#if PROJECT_VERSION_NUMBER >= 11600
+    using SpicyString = hilti::rt::String;
+#else
+    using SpicyString = std::string;
+#endif
+
+    SpicyString generateId() {
+        // Constructed once (function-static) rather than per-iteration:
+        // random_device is a seed source, not a PRNG, and re-seeding a
+        // fresh generator every iteration is both slow (repeated entropy
+        // syscalls) and risks producing identical bytes if random_device
+        // falls back to a deterministic sequence on a given platform.
+        // Zeek's packet-analysis path is single-threaded, so static
+        // (rather than thread_local) is safe here.
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<> dis(0, 255);
+
         std::stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
-            // Generate a random char
-            std::random_device rd;
-            std::mt19937 gen(rd());
-            std::uniform_int_distribution<> dis(0, 255);
             const auto rc = dis(gen);
 
             // Hex representaton of random char
@@ -26,6 +43,6 @@ namespace HART_IP_GENERATEID
             ss << (hex.length() < 2 ? '0' + hex : hex);
         }
         std::string result = ss.str();
-        return hilti::rt::String(std::string_view(result));
+        return {result};
     }
 }

--- a/analyzer/hart_ip_generateid.cc
+++ b/analyzer/hart_ip_generateid.cc
@@ -9,7 +9,7 @@
 namespace HART_IP_GENERATEID
 {
     #define ID_LEN 9
-    
+
     hilti::rt::String generateId() {
         std::stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
@@ -25,7 +25,7 @@ namespace HART_IP_GENERATEID
             auto hex = hexstream.str();
             ss << (hex.length() < 2 ? '0' + hex : hex);
         }
-        return ss.str();
+        std::string result = ss.str();
+        return hilti::rt::String(std::string_view(result));
     }
 }
-

--- a/analyzer/hart_ip_generateid.cc
+++ b/analyzer/hart_ip_generateid.cc
@@ -10,8 +10,8 @@ namespace HART_IP_GENERATEID
 {
     #define ID_LEN 9
     
-    std::string generateId() {
-        std::stringstream ss;
+    hilti::rt::String generateId() {
+        hilti::rt::Stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
             // Generate a random char
             std::random_device rd;
@@ -20,7 +20,7 @@ namespace HART_IP_GENERATEID
             const auto rc = dis(gen);
 
             // Hex representaton of random char
-            std::stringstream hexstream;
+            hilti::rt::Stringstream hexstream;
             hexstream << std::hex << rc;
             auto hex = hexstream.str();
             ss << (hex.length() < 2 ? '0' + hex : hex);

--- a/analyzer/hart_ip_generateid.cc
+++ b/analyzer/hart_ip_generateid.cc
@@ -11,7 +11,7 @@ namespace HART_IP_GENERATEID
     #define ID_LEN 9
     
     hilti::rt::String generateId() {
-        hilti::rt::Stringstream ss;
+        std::stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
             // Generate a random char
             std::random_device rd;
@@ -20,7 +20,7 @@ namespace HART_IP_GENERATEID
             const auto rc = dis(gen);
 
             // Hex representaton of random char
-            hilti::rt::Stringstream hexstream;
+            std::stringstream hexstream;
             hexstream << std::hex << rc;
             auto hex = hexstream.str();
             ss << (hex.length() < 2 ? '0' + hex : hex);


### PR DESCRIPTION
According to bbannier on the Zeek Slack:

> As for the undefined symbols you are seeing, spicy-1.16 [changed how Spicy string values are passed](https://github.com/zeek/spicy/blob/72b27c93eb8f32d60cf09555c0bfd20cebcadc70/NEWS.rst?plain=1#L66-L67). The fix should be to swap `std::string` uses out for `hilti::rt::String`.

This commit replaces `std::string` with `hilti::rt::String` to fix undefined symbol errors found at runtime with spicy 1.16 in Zeek 8.2.1.